### PR TITLE
fix: update go releaser in action file

### DIFF
--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -48,7 +48,7 @@ jobs:
         REPOSITORY: ${{ github.repository }}
         VERSION: ${{ steps.prep.outputs.version }}
       name: upload-binaries
-      uses: docker://goreleaser/goreleaser:v0.155.0
+      uses: docker://goreleaser/goreleaser:v1.4.1
       with:
         entrypoint: .github/workflows/jenkins-x/upload-binaries.sh
     - name: Set up QEMU


### PR DESCRIPTION
Follow up PR for M1 support. 
https://github.com/jenkins-x-plugins/jx-preview/pull/354
Changing the go version within the makefile did not have the wanted behavior. 

Another cause for not building arm darwin release is the set goreleaser within the github actions file. 

Please check.