### PR TITLE
check all service names

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -436,6 +436,18 @@ func (o *Options) createPreviewNamespace() (string, error) {
 	return prNamespace, nil
 }
 
+func findAllServiceNamesInNamespace(client kubernetes.Interface, namespace string) ([]string, error) {
+	services, err := client.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	appNames := []string{}
+	for _, service := range services.Items {
+		appNames = append(appNames, service.Name)
+	}
+	return appNames, nil
+}
+
 // findPreviewURL finds the preview URL
 func (o *Options) findPreviewURL(envVars map[string]string) (string, error) {
 
@@ -463,12 +475,12 @@ func (o *Options) findPreviewURL(envVars map[string]string) (string, error) {
 
 	log.Logger().Infof("found helm preview release %s in namespace %s", info(releaseName), info(releaseNamespace))
 
-	application := o.Repository
-	app := naming.ToValidName(application)
-
 	appNames := []string{o.PreviewService}
 	if o.PreviewService == "" {
-		appNames = []string{app, releaseName, o.Namespace + "-preview", releaseName + "-" + app}
+		appNames, err = findAllServiceNamesInNamespace(o.KubeClient, releaseNamespace)
+		if err != nil {
+			return "", fmt.Errorf("%v finding services in the preview namespace \n", err)
+		}
 	}
 
 	ctx := context.Background()

--- a/pkg/cmd/create/create_test.go
+++ b/pkg/cmd/create/create_test.go
@@ -53,6 +53,7 @@ func AssertPreview(t *testing.T, customService string) {
 	buildNumber := "2"
 	sha := "abcdef1234"
 	previewNamespace := ns + "-" + owner + "-" + repo + "-pr-" + strconv.Itoa(prNumber)
+	defaultService := "jx-service"
 
 	t.Logf("preview in namespace %s", previewNamespace)
 
@@ -62,7 +63,7 @@ func AssertPreview(t *testing.T, customService string) {
 
 	serviceName := customService
 	if serviceName == "" {
-		serviceName = repo
+		serviceName = defaultService
 	}
 
 	ingressHost := serviceName + ".1.2.3.4.nip.io"


### PR DESCRIPTION
Instead of doing random previewService in case we do not find o.PreviewService we should find all services in the releaseNamespace and try to find service url on them.