### PR TITLE
Should search for other services if one service returns error

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -490,7 +490,7 @@ func (o *Options) findPreviewURL(envVars map[string]string) (string, error) {
 				var err error
 				url, _, err = kserving.FindServiceURL(ctx, o.KServeClient, o.KubeClient, releaseNamespace, n)
 				if err != nil {
-					return errors.Wrapf(err, "failed to ")
+					log.Logger().Warnf("failed to find preview url in %s service %s", n, err.Error())
 				}
 			}
 			if url != "" {


### PR DESCRIPTION
If one service returns an error in FindServiceURL then it should not return an error instead it should search for all services and then return an error if it does not find any URL in any service.