### PR TITLE
fix: changing current-version to expected-version

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -11,8 +11,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 linterVersion="$(golangci-lint --version | awk '{print $4}')"
 
-if [ "${linterVersion}" != "1.46.2" ]; then
-	echo "Install GolangCI-Lint version ${linterVersion}"
+expectedLinterVersion=1.46.2
+
+if [ "${linterVersion}" != "${expectedLinterVersion}" ]; then
+	echo "Install GolangCI-Lint version ${expectedLinterVersion}"
   exit 1
 fi
 


### PR DESCRIPTION
- This PR shows the expected version of golangci-lint you need to run make lint
It was showing the current version earlier.

Signed-off-by: rajatgupta24 <rajat2411gupta@gmail.com>