### PR TITLE
feat: allow custom namespace for previews

### DIFF
--- a/.github/workflows/jenkins-x-pr.yaml
+++ b/.github/workflows/jenkins-x-pr.yaml
@@ -4,6 +4,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.3'
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: jx-variables
@@ -14,14 +17,14 @@ jobs:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: build-make-linux
-      uses: docker://golang:1.17.9
+      uses: docker://golang:1.19.3
       with:
         args: -c "make linux"
         entrypoint: /bin/sh
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: build-make-test
-      uses: docker://golang:1.17.9
+      uses: docker://golang:1.19.3
       with:
         args: -c "make test"
         entrypoint: /bin/sh
@@ -29,14 +32,23 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./Dockerfile
+        file: ./Dockerfile-preview
+        platforms: linux/amd64,linux/arm64
         push: false
-"on":
-  push:
-    branches-ignore:
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.event.number }}
+on:
+  pull_request:
+    branches:
     - main
     - master

--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -22,7 +22,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         VERSION: ${{ steps.prep.outputs.version }}
       name: release-binary
-      uses: docker://golang:1.17.9
+      uses: docker://golang:1.19.3
       with:
         args: -c "make release"
         entrypoint: bash

--- a/Dockerfile-preview
+++ b/Dockerfile-preview
@@ -1,3 +1,7 @@
-FROM gcr.io/jenkinsxio/jx-boot:3.0.739
+FROM golang:1.19.3
+WORKDIR /app
+COPY . /app/
+RUN make build
+RUN ls -ltr /app/
 
-COPY ./build/linux/jx-preview /usr/bin/jx-preview
+ENTRYPOINT ["/app/build/jx-preview"]

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -154,12 +154,12 @@ func (o *Options) Run() error {
 	// let's get the git clone URL with user/password so we can clone it again in the destroy command/CronJob
 	ctx := context.Background()
 
-	_, err = previews.CreateJXValuesFile(o.GitClient, o.JXClient, o.Namespace, filepath.Dir(o.PreviewHelmfile), o.PreviewNamespace, o.GitUser, o.GitToken)
+	_, err = previews.CreateJXValuesFile(o.GitClient, o.JXClient, o.Namespace, filepath.Dir(o.PreviewHelmfile), envVars["PREVIEW_NAMESPACE"], o.GitUser, o.GitToken)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create the jx-values.yaml file")
 	}
 
-	preview, _, err := previews.GetOrCreatePreview(o.PreviewClient, o.Namespace, pr, &destroyCmd, pr.Repository().Link, o.PreviewNamespace, o.PreviewHelmfile)
+	preview, _, err := previews.GetOrCreatePreview(o.PreviewClient, o.Namespace, pr, &destroyCmd, pr.Repository().Link, envVars["PREVIEW_NAMESPACE"], o.PreviewHelmfile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to upsert the Preview resource in namespace %s", o.Namespace)
 	}

--- a/pkg/previews/previews.go
+++ b/pkg/previews/previews.go
@@ -2,12 +2,10 @@ package previews
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/jenkins-x-plugins/jx-preview/pkg/apis/preview/v1alpha1"
 	"github.com/jenkins-x-plugins/jx-preview/pkg/client/clientset/versioned"
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/jx-helpers/v3/pkg/kube/naming"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +31,7 @@ func GetOrCreatePreview(client versioned.Interface, ns string, pr *scm.PullReque
 	var found *v1alpha1.Preview
 	for i := range previews.Items {
 		preview := &previews.Items[i]
-		prs := &preview.Spec.PullRequest
-		if prs.Number == pr.Number && prs.Repository == repo.Name && prs.Owner == repo.Namespace {
+		if preview.Name == previewNamespace {
 			found = preview
 			break
 		}
@@ -43,7 +40,7 @@ func GetOrCreatePreview(client versioned.Interface, ns string, pr *scm.PullReque
 		create = true
 		found = &v1alpha1.Preview{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      naming.ToValidName(repo.FullName + "-pr-" + strconv.Itoa(pr.Number)),
+				Name:      previewNamespace,
 				Namespace: ns,
 			},
 		}


### PR DESCRIPTION
This change allows you to define an environment variable `PREVIEW_NAMESPACE` which is used in place of the standard jx-org-repo-pr convention.  The inspiration for this was to allow a namespace per build, rather than pr