### PR TITLE
fix: correct location of default preview

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -669,7 +669,7 @@ func (o *Options) DiscoverPreviewHelmfile() error {
 	c := &cmdrunner.Command{
 		Dir:  o.Dir,
 		Name: "kpt",
-		Args: []string{"pkg", "get", "https://github.com/jenkins-x/jx3-gitops-template.git/charts/preview", relDir},
+		Args: []string{"pkg", "get", "https://github.com/jenkins-x/jx3-pipeline-catalog.git/helm/preview", relDir},
 	}
 	_, err = o.CommandRunner(c)
 	if err != nil {


### PR DESCRIPTION
When the preview directory is missing `jx-preview` is attempting to add a default one. This PR corrects the location of the default preview directory.