### PR TITLE
feat: support destroying previews for draft PRs as well

### DIFF
--- a/charts/jx-preview/templates/gc-jobs-cj.yaml
+++ b/charts/jx-preview/templates/gc-jobs-cj.yaml
@@ -26,7 +26,7 @@ spec:
             - command:
               - /bin/sh
               - -c
-              - jx gitops git setup --namespace {{ .Release.Namespace }} --secret tekton-git --git-provider {{ .Values.jxRequirements.cluster.gitServer | default "https://gitlab.com" }} && jx preview gc
+              - jx gitops git setup --namespace {{ .Release.Namespace }} --secret tekton-git --git-provider {{ .Values.jxRequirements.cluster.gitServer | default "https://gitlab.com" }} && jx preview gc {{ .Values.gcJobs.extraArgs }}
               env:
               - name: XDG_CONFIG_HOME
                 value: /home

--- a/charts/jx-preview/values.yaml
+++ b/charts/jx-preview/values.yaml
@@ -23,6 +23,9 @@ gcJobs:
   # gcJobs.concurrencyPolicy -- Drives the job's concurrency policy
   concurrencyPolicy: Forbid
 
+  # Extra arguments to the jx preview gc command
+  extraArgs: ""
+
 
 jxRequirements:
   cluster:


### PR DESCRIPTION
This fits with the option for skipping builds for PRs. If you accidentally create a PR normally so a preview is created you could with this setting undo that by converting to draft.