### PR TITLE
chore: bump syft version

### DIFF
--- a/.github/workflows/jenkins-x/sbom-container.sh
+++ b/.github/workflows/jenkins-x/sbom-container.sh
@@ -3,7 +3,7 @@
 # Install syft in this script
 apk add --no-cache curl unzip
 curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
-sh -s -- -b /usr/local/bin v0.55.0
+sh -s -- -b /usr/local/bin v1.43.0
 chmod +x /usr/local/bin/syft
 
 # Generate SBOM

--- a/.github/workflows/jenkins-x/upload-binaries.sh
+++ b/.github/workflows/jenkins-x/upload-binaries.sh
@@ -27,7 +27,7 @@ export ROOTPACKAGE="github.com/$REPOSITORY"
 
 # Install syft in this script
 curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
-sh -s -- -b /usr/local/bin v0.54.0
+sh -s -- -b /usr/local/bin v1.43.0
 chmod +x /usr/local/bin/syft
 
 goreleaser release


### PR DESCRIPTION
Bump syft version to `v1.43.0` to match the version used by `jx-goreleaser-image`

Part of https://github.com/jenkins-x/jx/issues/8965