### PR TITLE
fix(gc): log-and-skip per-preview errors instead of halting the whole run

### DIFF
--- a/pkg/cmd/gc/gc.go
+++ b/pkg/cmd/gc/gc.go
@@ -129,7 +129,8 @@ func (o *Options) Run() error {
 		}
 		err = so.Validate()
 		if err != nil {
-			return fmt.Errorf("failed to validate preview %s with source URL %s: %w", name, preview.Spec.Source.URL, err)
+			log.Logger().Warnf("cannot GC preview %s: failed to validate source URL %s: %s; skipping", name, preview.Spec.Source.URL, err)
+			continue
 		}
 
 		scmClient := so.ScmClient
@@ -138,14 +139,16 @@ func (o *Options) Run() error {
 		ctx := context.Background()
 		pullRequest, _, err := scmClient.PullRequests.Find(ctx, fullName, prNumber)
 		if err != nil {
-			return fmt.Errorf("failed to query PullRequest %s: %w", prLink, err)
+			log.Logger().Warnf("cannot GC preview %s: failed to query PullRequest %s: %s; skipping", name, prLink, err)
+			continue
 		}
 
 		if pullRequest.Closed || pullRequest.Merged || (o.DestroyDrafts && pullRequest.Draft && !scmhelpers.ContainsLabel(pullRequest.Labels, "ok-to-test")) {
 			if !o.DryRun {
 				err = o.Destroy(name)
 				if err != nil {
-					return fmt.Errorf("failed to destroy preview environment %s: %v", name, err)
+					log.Logger().Warnf("failed to destroy preview environment %s: %s; skipping", name, err)
+					continue
 				}
 			} else {
 				log.Logger().Info(name)


### PR DESCRIPTION
## Summary

Converts three per-preview error paths inside `Options.Run()` (`pkg/cmd/gc/gc.go`) from halting-with-error to log-and-continue, consistent with the pattern already used earlier in the same loop for missing `spec.source.cloneURL` / `spec.pullRequest` fields.

**Before** — first error inside the loop halts the entire GC run:

```go
pullRequest, _, err := scmClient.PullRequests.Find(ctx, fullName, prNumber)
if err != nil {
    return fmt.Errorf("failed to query PullRequest %s: %w", prLink, err)
}
```

**After** — that Preview is skipped, other Previews still get processed:

```go
pullRequest, _, err := scmClient.PullRequests.Find(ctx, fullName, prNumber)
if err != nil {
    log.Logger().Warnf("cannot GC preview %s: failed to query PullRequest %s: %s; skipping", name, prLink, err)
    continue
}
```

Same treatment for the earlier `scmhelpers.Options.Validate()` failure and the later `o.Destroy(name)` failure — all three convert `return fmt.Errorf(...)` to `log.Logger().Warnf(...) + continue`. The outer function still returns cleanly on truly fatal errors (the `Previews.List()` failure at the top).

## Motivation

We hit this in production. A single Preview CR referenced a GitHub repo that had been deleted. `PullRequests.Find` returned a 404 for it. The current `return` on that error halted every `jx-preview-gc` cron invocation from that moment onward. Preview namespaces of merged / closed PRs accumulated silently for **114 days** before an internal report surfaced it. Root cause was easy to fix (delete the orphan Preview CR), but only after we knew where to look — the only visible symptom was the pod-status of each `Failed` scheduled Job, which nothing surfaced.

With this change:
- The offending Preview stays in place so an operator can still investigate it (log line names it explicitly).
- The rest of the GC cycle completes as normal.
- Next scheduled tick retries the offending Preview, so transient SCM-side flakes / rate limits self-heal.
- No orphan namespaces accumulate.

## Behavioural notes

- **Failure classes now non-fatal per preview:**
  - `scmhelpers.Options.Validate()` — cannot resolve source URL / SCM client for a specific preview.
  - `scmClient.PullRequests.Find()` — PR / repo no longer exists, or transient SCM error.
  - `o.Destroy(name)` — one preview's Helm destroy fails (partial namespace state, missing chart, etc.).
- **Still fatal (unchanged):** initial `Previews.List()` failure at the top of `Run()` (returns as before, since without the list nothing else can proceed).
- **Log level:** `Warn` for all three — matches the existing pattern used earlier in the loop for missing spec fields. Operator-visible via the standard `jx-logging` sink.

## Testing

- Manual: reproduced our production case by creating a Preview CR pointing at a non-existent PR, ran `jx preview gc`, confirmed the run now completes and processes remaining valid Previews (with a `Warnf` line naming the skipped one). Repeated for the `Destroy`-fails-mid-run case using a broken helmfile.
- No existing test-cases in `pkg/cmd/gc/gc_test.go` exercise these paths directly. Happy to add sub-cases if maintainers want — the existing table-test structure covers success paths only today.